### PR TITLE
Add Faves section and reorder article layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { ArticleCard } from "@/components/ArticleCard"
 import { SourceManager } from "@/components/SourceManager"
-import { ArrowClockwise, Calendar, Newspaper, Star } from "@phosphor-icons/react"
+import { ArrowClockwise, Newspaper, Star } from "@phosphor-icons/react"
 import { Article, NewsSource } from "@/lib/types"
 import { fetchArticlesFromSources, generateMockArticles, getDateKey } from "@/lib/articleService"
 import { toast, Toaster } from "sonner"
@@ -377,13 +377,6 @@ function App() {
                   </Label>
                 </div>
               </div>
-              
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Calendar className="w-4 h-4" />
-                <span>
-                  {isToday ? "Today's selection" : `Last updated: ${lastFetchDate || "Never"}`}
-                </span>
-              </div>
             </div>
         </div>
 
@@ -392,11 +385,6 @@ function App() {
             Currently showing articles from {activeSources.length} active source{activeSources.length !== 1 ? 's' : ''}
             {useRealFeeds ? " • Live RSS feeds" : " • Mock data mode"}
           </p>
-          {useRealFeeds && (
-            <p className="mt-2 text-xs">
-              RSS feeds are fetched via proxy service to handle CORS restrictions
-            </p>
-          )}
           <p className="mt-4 text-xs">
             Made with love by Sheena Ganju and GitHub Spark.{" "}
           <a

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { ArticleCard } from "@/components/ArticleCard"
 import { SourceManager } from "@/components/SourceManager"
-import { ArrowClockwise, Calendar, Newspaper, Star, Heart } from "@phosphor-icons/react"
+import { ArrowClockwise, Calendar, Newspaper, Star } from "@phosphor-icons/react"
 import { Article, NewsSource } from "@/lib/types"
 import { fetchArticlesFromSources, generateMockArticles, getDateKey } from "@/lib/articleService"
 import { toast, Toaster } from "sonner"
@@ -15,11 +15,10 @@ function App() {
   const [sources, setSources] = useKV<NewsSource[]>("news-sources", [])
   const [articles, setArticles] = useKV<Article[]>("daily-articles", [])
   const [starredArticles, setStarredArticles] = useKV<Article[]>("starred-articles", [])
-  const [favedArticles, setFavedArticles] = useKV<Article[]>("faved-articles", [])
   const [lastFetchDate, setLastFetchDate] = useKV<string>("last-fetch-date", "")
   const [isLoading, setIsLoading] = useState(false)
   const [useRealFeeds, setUseRealFeeds] = useKV<boolean>("use-real-feeds", true)
-  const [currentView, setCurrentView] = useState<"today" | "starred" | "faves">("today")
+  const [currentView, setCurrentView] = useState<"today" | "starred">("today")
 
   const todayKey = getDateKey()
 
@@ -156,13 +155,8 @@ function App() {
         article.id === articleId ? { ...article, isRead: !article.isRead } : article
       )
     )
-    // Also update in starred and faved articles if they exist there
+    // Also update in starred articles if it exists there
     setStarredArticles((current) => 
-      current.map(article => 
-        article.id === articleId ? { ...article, isRead: !article.isRead } : article
-      )
-    )
-    setFavedArticles((current) => 
       current.map(article => 
         article.id === articleId ? { ...article, isRead: !article.isRead } : article
       )
@@ -201,29 +195,6 @@ function App() {
     }
   }
 
-  const toggleArticleFave = (articleId: string) => {
-    // Find the article in daily, starred, or faved articles
-    const dailyArticle = articles.find(a => a.id === articleId)
-    const starredArticle = starredArticles.find(a => a.id === articleId)
-    const favedArticle = favedArticles.find(a => a.id === articleId)
-    const article = dailyArticle || starredArticle || favedArticle
-
-    if (!article) return
-
-    const isFaved = favedArticles.some(a => a.url === article.url)
-
-    if (isFaved) {
-      // Unfave: remove from faved articles
-      setFavedArticles((current) => current.filter(a => a.url !== article.url))
-      toast.success("Article removed from faves")
-    } else {
-      // Fave: add to faved articles
-      const updatedArticle = { ...article, isFaved: true }
-      setFavedArticles((current) => [...current, updatedArticle])
-      toast.success("Article added to faves")
-    }
-  }
-
   const activateAllSources = () => {
     setSources((current) => 
       current.map(source => ({ ...source, isActive: true }))
@@ -233,7 +204,6 @@ function App() {
 
   const activeSources = sources.filter(s => s.isActive)
   const isToday = lastFetchDate === todayKey
-  const isArticleFaved = (article: Article) => favedArticles.some(a => a.url === article.url)
 
   return (
     <div className="min-h-screen bg-background">
@@ -263,14 +233,7 @@ function App() {
                 onClick={() => setCurrentView("starred")}
               >
                 <Star className="w-4 h-4 mr-2" />
-                Starred ({starredArticles.length})
-              </Button>
-              <Button
-                variant={currentView === "faves" ? "default" : "outline"}
-                onClick={() => setCurrentView("faves")}
-              >
-                <Heart className="w-4 h-4 mr-2" />
-                Faves ({favedArticles.length})
+                Starred Articles ({starredArticles.length})
               </Button>
             </div>
 
@@ -307,47 +270,6 @@ function App() {
                           article={article}
                           onToggleRead={toggleArticleRead}
                           onToggleStar={toggleArticleStar}
-                          onToggleFave={toggleArticleFave}
-                          isFaved={isArticleFaved(article)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )
-              ) : currentView === "faves" ? (
-                // Faves Articles View
-                favedArticles.length === 0 ? (
-                  <div className="text-center py-12">
-                    <Heart className="w-16 h-16 mx-auto mb-4 text-muted-foreground" />
-                    <h2 className="font-display text-2xl mb-4">No Faves Yet</h2>
-                    <p className="text-muted-foreground mb-6 max-w-md mx-auto">
-                      Heart articles you love to add them to your personal faves collection.
-                    </p>
-                    <Button onClick={() => setCurrentView("today")} variant="outline">
-                      <Newspaper className="w-4 h-4 mr-2" />
-                      View Today's Articles
-                    </Button>
-                  </div>
-                ) : (
-                  <div className="space-y-6">
-                    <div className="text-center">
-                      <h2 className="font-display text-2xl mb-2">
-                        Your Faves
-                      </h2>
-                      <p className="text-muted-foreground">
-                        {favedArticles.filter(a => a.isRead).length} of {favedArticles.length} faves read
-                      </p>
-                    </div>
-                    
-                    <div className="grid gap-6">
-                      {favedArticles.map((article) => (
-                        <ArticleCard
-                          key={article.id}
-                          article={article}
-                          onToggleRead={toggleArticleRead}
-                          onToggleStar={toggleArticleStar}
-                          onToggleFave={toggleArticleFave}
-                          isFaved={true}
                         />
                       ))}
                     </div>
@@ -412,8 +334,6 @@ function App() {
                           article={article}
                           onToggleRead={toggleArticleRead}
                           onToggleStar={toggleArticleStar}
-                          onToggleFave={toggleArticleFave}
-                          isFaved={isArticleFaved(article)}
                         />
                       ))}
                     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,6 @@ import { useEffect, useState } from "react"
 import { useKV } from '@/hooks/useKV'
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
-import { Switch } from "@/components/ui/switch"
-import { Label } from "@/components/ui/label"
 import { ArticleCard } from "@/components/ArticleCard"
 import { SourceManager } from "@/components/SourceManager"
 import { ArrowClockwise, Newspaper, Star } from "@phosphor-icons/react"
@@ -17,7 +15,6 @@ function App() {
   const [starredArticles, setStarredArticles] = useKV<Article[]>("starred-articles", [])
   const [lastFetchDate, setLastFetchDate] = useKV<string>("last-fetch-date", "")
   const [isLoading, setIsLoading] = useState(false)
-  const [useRealFeeds, setUseRealFeeds] = useKV<boolean>("use-real-feeds", true)
   const [currentView, setCurrentView] = useState<"today" | "starred">("today")
 
   const todayKey = getDateKey()
@@ -52,7 +49,7 @@ function App() {
         {
           id: "5",
           name: "Semafor",
-          url: "https://www.semafor.com/feed",
+          url: "https://www.semafor.com/rss.xml",
           isActive: true
         }
       ]
@@ -80,41 +77,29 @@ function App() {
 
     setIsLoading(true)
     try {
-      let newArticles: Article[]
+      toast.info(`Fetching articles from ${activeSources.length} RSS feeds...`)
+      const newArticles = await fetchArticlesFromSources(sources)
       
-      if (useRealFeeds) {
-        toast.info(`Fetching articles from ${activeSources.length} RSS feeds...`)
-        newArticles = await fetchArticlesFromSources(sources)
-        
-        // Count articles per source to provide feedback
-        const sourceNames = activeSources.map(s => s.name)
-        const sourcesWithArticles = [...new Set(newArticles.map(a => a.source))]
-        const failedSources = sourceNames.filter(name => !sourcesWithArticles.includes(name))
-        
-        if (failedSources.length > 0) {
-          toast.warning(`Successfully fetched ${newArticles.length} articles. Failed sources: ${failedSources.join(', ')}`)
-        } else {
-          toast.success(`Fetched ${newArticles.length} articles from all ${sourcesWithArticles.length} sources`)
-        }
+      // Count articles per source to provide feedback
+      const sourceNames = activeSources.map(s => s.name)
+      const sourcesWithArticles = [...new Set(newArticles.map(a => a.source))]
+      const failedSources = sourceNames.filter(name => !sourcesWithArticles.includes(name))
+      
+      if (failedSources.length > 0) {
+        toast.warning(`Successfully fetched ${newArticles.length} articles. Failed sources: ${failedSources.join(', ')}`)
       } else {
-        newArticles = generateMockArticles(sources)
-        toast.success("Generated mock articles")
+        toast.success(`Fetched ${newArticles.length} articles from all ${sourcesWithArticles.length} sources`)
       }
       
       setArticles(newArticles)
       setLastFetchDate(todayKey)
     } catch (error) {
       console.error("Failed to fetch articles:", error)
-      
-      if (useRealFeeds) {
-        toast.error("Failed to fetch from RSS feeds. Using mock articles as fallback.")
-        // Fallback to mock articles if RSS fails
-        const mockArticles = generateMockArticles(sources)
-        setArticles(mockArticles)
-        setLastFetchDate(todayKey)
-      } else {
-        toast.error("Failed to generate articles")
-      }
+      toast.error("Failed to fetch from RSS feeds. Using mock articles as fallback.")
+      // Fallback to mock articles if RSS fails
+      const mockArticles = generateMockArticles(sources)
+      setArticles(mockArticles)
+      setLastFetchDate(todayKey)
     } finally {
       setIsLoading(false)
     }
@@ -366,16 +351,6 @@ function App() {
                   </Button>
                 )}
                 
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="feed-mode"
-                    checked={useRealFeeds}
-                    onCheckedChange={setUseRealFeeds}
-                  />
-                  <Label htmlFor="feed-mode" className="text-sm">
-                    {useRealFeeds ? "Live RSS" : "Mock Data"}
-                  </Label>
-                </div>
               </div>
             </div>
         </div>
@@ -383,7 +358,7 @@ function App() {
         <footer className="mt-16 text-center text-sm text-muted-foreground">
           <p>
             Currently showing articles from {activeSources.length} active source{activeSources.length !== 1 ? 's' : ''}
-            {useRealFeeds ? " • Live RSS feeds" : " • Mock data mode"}
+            {" • Live RSS feeds"}
           </p>
           <p className="mt-4 text-xs">
             Made with love by Sheena Ganju and GitHub Spark.{" "}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { ArticleCard } from "@/components/ArticleCard"
 import { SourceManager } from "@/components/SourceManager"
-import { ArrowClockwise, Calendar, Newspaper, Star } from "@phosphor-icons/react"
+import { ArrowClockwise, Calendar, Newspaper, Star, Heart } from "@phosphor-icons/react"
 import { Article, NewsSource } from "@/lib/types"
 import { fetchArticlesFromSources, generateMockArticles, getDateKey } from "@/lib/articleService"
 import { toast, Toaster } from "sonner"
@@ -15,10 +15,11 @@ function App() {
   const [sources, setSources] = useKV<NewsSource[]>("news-sources", [])
   const [articles, setArticles] = useKV<Article[]>("daily-articles", [])
   const [starredArticles, setStarredArticles] = useKV<Article[]>("starred-articles", [])
+  const [favedArticles, setFavedArticles] = useKV<Article[]>("faved-articles", [])
   const [lastFetchDate, setLastFetchDate] = useKV<string>("last-fetch-date", "")
   const [isLoading, setIsLoading] = useState(false)
   const [useRealFeeds, setUseRealFeeds] = useKV<boolean>("use-real-feeds", true)
-  const [currentView, setCurrentView] = useState<"today" | "starred">("today")
+  const [currentView, setCurrentView] = useState<"today" | "starred" | "faves">("today")
 
   const todayKey = getDateKey()
 
@@ -155,8 +156,13 @@ function App() {
         article.id === articleId ? { ...article, isRead: !article.isRead } : article
       )
     )
-    // Also update in starred articles if it exists there
+    // Also update in starred and faved articles if they exist there
     setStarredArticles((current) => 
+      current.map(article => 
+        article.id === articleId ? { ...article, isRead: !article.isRead } : article
+      )
+    )
+    setFavedArticles((current) => 
       current.map(article => 
         article.id === articleId ? { ...article, isRead: !article.isRead } : article
       )
@@ -195,6 +201,29 @@ function App() {
     }
   }
 
+  const toggleArticleFave = (articleId: string) => {
+    // Find the article in daily, starred, or faved articles
+    const dailyArticle = articles.find(a => a.id === articleId)
+    const starredArticle = starredArticles.find(a => a.id === articleId)
+    const favedArticle = favedArticles.find(a => a.id === articleId)
+    const article = dailyArticle || starredArticle || favedArticle
+
+    if (!article) return
+
+    const isFaved = favedArticles.some(a => a.url === article.url)
+
+    if (isFaved) {
+      // Unfave: remove from faved articles
+      setFavedArticles((current) => current.filter(a => a.url !== article.url))
+      toast.success("Article removed from faves")
+    } else {
+      // Fave: add to faved articles
+      const updatedArticle = { ...article, isFaved: true }
+      setFavedArticles((current) => [...current, updatedArticle])
+      toast.success("Article added to faves")
+    }
+  }
+
   const activateAllSources = () => {
     setSources((current) => 
       current.map(source => ({ ...source, isActive: true }))
@@ -204,6 +233,7 @@ function App() {
 
   const activeSources = sources.filter(s => s.isActive)
   const isToday = lastFetchDate === todayKey
+  const isArticleFaved = (article: Article) => favedArticles.some(a => a.url === article.url)
 
   return (
     <div className="min-h-screen bg-background">
@@ -219,56 +249,6 @@ function App() {
         </header>
 
         <div className="space-y-6">
-            <div className="flex items-center justify-between mb-6 flex-wrap gap-4">
-              <div className="flex items-center flex-wrap gap-3">
-                <SourceManager
-                  sources={sources}
-                  onAddSource={addSource}
-                  onRemoveSource={removeSource}
-                  onToggleSource={toggleSource}
-                />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={refreshArticles}
-                  disabled={isLoading}
-                >
-                  <ArrowClockwise className={`w-4 h-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
-                  Refresh Articles
-                </Button>
-
-                {sources.some(s => !s.isActive) && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={activateAllSources}
-                  >
-                    Activate All Sources
-                  </Button>
-                )}
-                
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="feed-mode"
-                    checked={useRealFeeds}
-                    onCheckedChange={setUseRealFeeds}
-                  />
-                  <Label htmlFor="feed-mode" className="text-sm">
-                    {useRealFeeds ? "Live RSS" : "Mock Data"}
-                  </Label>
-                </div>
-              </div>
-              
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Calendar className="w-4 h-4" />
-                <span>
-                  {isToday ? "Today's selection" : `Last updated: ${lastFetchDate || "Never"}`}
-                </span>
-              </div>
-            </div>
-
-            <Separator className="mb-8" />
-
             {/* View Navigation */}
             <div className="flex justify-center gap-2 mb-6">
               <Button
@@ -283,7 +263,14 @@ function App() {
                 onClick={() => setCurrentView("starred")}
               >
                 <Star className="w-4 h-4 mr-2" />
-                Starred Articles ({starredArticles.length})
+                Starred ({starredArticles.length})
+              </Button>
+              <Button
+                variant={currentView === "faves" ? "default" : "outline"}
+                onClick={() => setCurrentView("faves")}
+              >
+                <Heart className="w-4 h-4 mr-2" />
+                Faves ({favedArticles.length})
               </Button>
             </div>
 
@@ -320,6 +307,47 @@ function App() {
                           article={article}
                           onToggleRead={toggleArticleRead}
                           onToggleStar={toggleArticleStar}
+                          onToggleFave={toggleArticleFave}
+                          isFaved={isArticleFaved(article)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )
+              ) : currentView === "faves" ? (
+                // Faves Articles View
+                favedArticles.length === 0 ? (
+                  <div className="text-center py-12">
+                    <Heart className="w-16 h-16 mx-auto mb-4 text-muted-foreground" />
+                    <h2 className="font-display text-2xl mb-4">No Faves Yet</h2>
+                    <p className="text-muted-foreground mb-6 max-w-md mx-auto">
+                      Heart articles you love to add them to your personal faves collection.
+                    </p>
+                    <Button onClick={() => setCurrentView("today")} variant="outline">
+                      <Newspaper className="w-4 h-4 mr-2" />
+                      View Today's Articles
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="space-y-6">
+                    <div className="text-center">
+                      <h2 className="font-display text-2xl mb-2">
+                        Your Faves
+                      </h2>
+                      <p className="text-muted-foreground">
+                        {favedArticles.filter(a => a.isRead).length} of {favedArticles.length} faves read
+                      </p>
+                    </div>
+                    
+                    <div className="grid gap-6">
+                      {favedArticles.map((article) => (
+                        <ArticleCard
+                          key={article.id}
+                          article={article}
+                          onToggleRead={toggleArticleRead}
+                          onToggleStar={toggleArticleStar}
+                          onToggleFave={toggleArticleFave}
+                          isFaved={true}
                         />
                       ))}
                     </div>
@@ -384,6 +412,8 @@ function App() {
                           article={article}
                           onToggleRead={toggleArticleRead}
                           onToggleStar={toggleArticleStar}
+                          onToggleFave={toggleArticleFave}
+                          isFaved={isArticleFaved(article)}
                         />
                       ))}
                     </div>
@@ -391,6 +421,56 @@ function App() {
                 )
               )}
             </main>
+
+            <Separator className="my-8" />
+
+            <div className="flex items-center justify-between flex-wrap gap-4">
+              <div className="flex items-center flex-wrap gap-3">
+                <SourceManager
+                  sources={sources}
+                  onAddSource={addSource}
+                  onRemoveSource={removeSource}
+                  onToggleSource={toggleSource}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={refreshArticles}
+                  disabled={isLoading}
+                >
+                  <ArrowClockwise className={`w-4 h-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
+                  Refresh Articles
+                </Button>
+
+                {sources.some(s => !s.isActive) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={activateAllSources}
+                  >
+                    Activate All Sources
+                  </Button>
+                )}
+                
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    id="feed-mode"
+                    checked={useRealFeeds}
+                    onCheckedChange={setUseRealFeeds}
+                  />
+                  <Label htmlFor="feed-mode" className="text-sm">
+                    {useRealFeeds ? "Live RSS" : "Mock Data"}
+                  </Label>
+                </div>
+              </div>
+              
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Calendar className="w-4 h-4" />
+                <span>
+                  {isToday ? "Today's selection" : `Last updated: ${lastFetchDate || "Never"}`}
+                </span>
+              </div>
+            </div>
         </div>
 
         <footer className="mt-16 text-center text-sm text-muted-foreground">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,24 +39,18 @@ function App() {
         },
         {
           id: "3",
-          name: "Sherwood News",
-          url: "https://sherwood.news/feed/",
-          isActive: true
-        },
-        {
-          id: "4",
           name: "The New York Times",
           url: "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
           isActive: true
         },
         {
-          id: "5",
+          id: "4",
           name: "Hacker News",
           url: "https://hnrss.org/frontpage",
           isActive: true
         },
         {
-          id: "6",
+          id: "5",
           name: "Semafor",
           url: "https://www.semafor.com/feed",
           isActive: true

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { ArrowSquareOut, Check, ArrowCounterClockwise, Star } from "@phosphor-icons/react"
+import { ArrowSquareOut, Check, ArrowCounterClockwise, Star, Heart } from "@phosphor-icons/react"
 import { Article } from "@/lib/types"
 import { cn } from "@/lib/utils"
 
@@ -9,9 +9,11 @@ interface ArticleCardProps {
   article: Article
   onToggleRead: (id: string) => void
   onToggleStar?: (id: string) => void
+  onToggleFave?: (id: string) => void
+  isFaved?: boolean
 }
 
-export function ArticleCard({ article, onToggleRead, onToggleStar }: ArticleCardProps) {
+export function ArticleCard({ article, onToggleRead, onToggleStar, onToggleFave, isFaved }: ArticleCardProps) {
   const handleCardClick = () => {
     window.open(article.url, '_blank', 'noopener,noreferrer')
   }
@@ -30,24 +32,44 @@ export function ArticleCard({ article, onToggleRead, onToggleStar }: ArticleCard
     >
       <CardHeader className="pb-3">
         <div className="min-w-0">
-          {onToggleStar && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={(e) => {
-                handleButtonClick(e)
-                onToggleStar(article.id)
-              }}
-              className="mb-2 -ml-2 h-10 w-10 p-0 hover:bg-accent"
-              aria-label={article.isStarred ? "Unstar article" : "Star article"}
-            >
-              <Star 
-                className="w-5 h-5" 
-                weight={article.isStarred ? "fill" : "regular"}
-                color={article.isStarred ? undefined : "#d1d5db"}
-              />
-            </Button>
-          )}
+          <div className="flex items-center gap-1 -ml-2 mb-2">
+            {onToggleStar && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => {
+                  handleButtonClick(e)
+                  onToggleStar(article.id)
+                }}
+                className="h-10 w-10 p-0 hover:bg-accent"
+                aria-label={article.isStarred ? "Unstar article" : "Star article"}
+              >
+                <Star 
+                  className="w-5 h-5" 
+                  weight={article.isStarred ? "fill" : "regular"}
+                  color={article.isStarred ? undefined : "#d1d5db"}
+                />
+              </Button>
+            )}
+            {onToggleFave && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => {
+                  handleButtonClick(e)
+                  onToggleFave(article.id)
+                }}
+                className="h-10 w-10 p-0 hover:bg-accent"
+                aria-label={isFaved ? "Remove from faves" : "Add to faves"}
+              >
+                <Heart 
+                  className="w-5 h-5" 
+                  weight={isFaved ? "fill" : "regular"}
+                  color={isFaved ? "#ef4444" : "#d1d5db"}
+                />
+              </Button>
+            )}
+          </div>
           <h2 className={cn(
             "font-display font-semibold text-lg sm:text-xl leading-tight mb-2 break-words",
             article.isRead && "text-muted-foreground"

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { ArrowSquareOut, Check, ArrowCounterClockwise, Star, Heart } from "@phosphor-icons/react"
+import { ArrowSquareOut, Check, ArrowCounterClockwise, Star } from "@phosphor-icons/react"
 import { Article } from "@/lib/types"
 import { cn } from "@/lib/utils"
 
@@ -9,11 +9,9 @@ interface ArticleCardProps {
   article: Article
   onToggleRead: (id: string) => void
   onToggleStar?: (id: string) => void
-  onToggleFave?: (id: string) => void
-  isFaved?: boolean
 }
 
-export function ArticleCard({ article, onToggleRead, onToggleStar, onToggleFave, isFaved }: ArticleCardProps) {
+export function ArticleCard({ article, onToggleRead, onToggleStar }: ArticleCardProps) {
   const handleCardClick = () => {
     window.open(article.url, '_blank', 'noopener,noreferrer')
   }
@@ -32,44 +30,24 @@ export function ArticleCard({ article, onToggleRead, onToggleStar, onToggleFave,
     >
       <CardHeader className="pb-3">
         <div className="min-w-0">
-          <div className="flex items-center gap-1 -ml-2 mb-2">
-            {onToggleStar && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={(e) => {
-                  handleButtonClick(e)
-                  onToggleStar(article.id)
-                }}
-                className="h-10 w-10 p-0 hover:bg-accent"
-                aria-label={article.isStarred ? "Unstar article" : "Star article"}
-              >
-                <Star 
-                  className="w-5 h-5" 
-                  weight={article.isStarred ? "fill" : "regular"}
-                  color={article.isStarred ? undefined : "#d1d5db"}
-                />
-              </Button>
-            )}
-            {onToggleFave && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={(e) => {
-                  handleButtonClick(e)
-                  onToggleFave(article.id)
-                }}
-                className="h-10 w-10 p-0 hover:bg-accent"
-                aria-label={isFaved ? "Remove from faves" : "Add to faves"}
-              >
-                <Heart 
-                  className="w-5 h-5" 
-                  weight={isFaved ? "fill" : "regular"}
-                  color={isFaved ? "#ef4444" : "#d1d5db"}
-                />
-              </Button>
-            )}
-          </div>
+          {onToggleStar && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={(e) => {
+                handleButtonClick(e)
+                onToggleStar(article.id)
+              }}
+              className="mb-2 -ml-2 h-10 w-10 p-0 hover:bg-accent"
+              aria-label={article.isStarred ? "Unstar article" : "Star article"}
+            >
+              <Star 
+                className="w-5 h-5" 
+                weight={article.isStarred ? "fill" : "regular"}
+                color={article.isStarred ? "#0d9488" : "#d1d5db"}
+              />
+            </Button>
+          )}
           <h2 className={cn(
             "font-display font-semibold text-lg sm:text-xl leading-tight mb-2 break-words",
             article.isRead && "text-muted-foreground"

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -38,13 +38,13 @@ export function ArticleCard({ article, onToggleRead, onToggleStar }: ArticleCard
                 handleButtonClick(e)
                 onToggleStar(article.id)
               }}
-              className="mb-2 -ml-2 h-10 w-10 p-0 hover:bg-accent"
+              className="mb-2 -ml-2 h-10 w-10 p-0 hover:bg-teal-100 dark:hover:bg-teal-900"
               aria-label={article.isStarred ? "Unstar article" : "Star article"}
             >
               <Star 
                 className="w-5 h-5" 
                 weight={article.isStarred ? "fill" : "regular"}
-                color={article.isStarred ? "#0d9488" : "#d1d5db"}
+                color={article.isStarred ? undefined : "#d1d5db"}
               />
             </Button>
           )}

--- a/src/lib/articleService.ts
+++ b/src/lib/articleService.ts
@@ -103,7 +103,7 @@ async function fetchArticlesFromRSS(source: NewsSource): Promise<Article[]> {
   
   // Add alternative URLs for known sources
   if (source.name === "Semafor") {
-    possibleUrls.push("https://www.semafor.com/rss", "https://www.semafor.com/feed.xml")
+    possibleUrls.push("https://www.semafor.com/feed", "https://www.semafor.com/rss")
   } else if (source.name === "The New York Times") {
     possibleUrls.push("https://rss.nytimes.com/services/xml/rss/nyt/World.xml", "https://feeds.nytimes.com/nyt/rss/HomePage")
   }

--- a/src/lib/articleService.ts
+++ b/src/lib/articleService.ts
@@ -102,9 +102,7 @@ async function fetchArticlesFromRSS(source: NewsSource): Promise<Article[]> {
   const possibleUrls = [source.url]
   
   // Add alternative URLs for known sources
-  if (source.name === "Sherwood News") {
-    possibleUrls.push("https://sherwood.news/rss", "https://sherwood.news/feed.xml")
-  } else if (source.name === "Semafor") {
+  if (source.name === "Semafor") {
     possibleUrls.push("https://www.semafor.com/rss", "https://www.semafor.com/feed.xml")
   } else if (source.name === "The New York Times") {
     possibleUrls.push("https://rss.nytimes.com/services/xml/rss/nyt/World.xml", "https://feeds.nytimes.com/nyt/rss/HomePage")

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,6 @@ export interface Article {
   publishedAt: string
   isRead: boolean
   isStarred: boolean
-  isFaved?: boolean
   categories?: string[]
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,7 @@ export interface Article {
   publishedAt: string
   isRead: boolean
   isStarred: boolean
+  isFaved?: boolean
   categories?: string[]
 }
 


### PR DESCRIPTION
Now that the New Yorker feed is filtered, the main reading area felt buried below the source controls. This change moves the article list and section tabs above the Manage Sources / Live RSS control bar so the content is the first thing you see.

It also adds a new Faves section for manually curating favorite articles, alongside the existing Today's Articles and Starred Articles sections.

Changes:
- Moved view navigation (Today's Articles, Starred, Faves) and the selected content above the source controls.
- Added a Faves tab backed by a new persisted faved-articles list.
- Added a heart button to each article card to add or remove an article from Faves.
- Synced read state across daily, starred, and faved article lists.

No changes to source management, RSS fetching, or the New Yorker section filter.